### PR TITLE
[SNOW-904863]: Render README.md from Jinja + Some Refactor

### DIFF
--- a/src/snowcli/cli/render/commands.py
+++ b/src/snowcli/cli/render/commands.py
@@ -142,16 +142,35 @@ def render_template(
             key, value = _parse_key_value(key_value_str)
             data[key] = value
 
+    generic_render_template(
+        template_path=template_path, data=data, output_file_path=output_file_path
+    )
+
+
+def generic_render_template(
+    template_path: Path, data: dict, output_file_path: Optional[Path]
+):
+    """
+    Create a file from a jinja template.
+
+    Args:
+        template_path (Path): Path to the template
+        data (dict): A dictionary of jinja variables and their actual values
+        output_file_path (Optional[Path]): If provided then rendered template will be written to this file
+
+    Returns:
+        None
+    """
     env = jinja2.Environment(
-        loader=jinja2.loaders.FileSystemLoader(template_path.parent)
+        loader=jinja2.loaders.FileSystemLoader(template_path.parent),
+        keep_trailing_newline=True,
     )
     filters = [render_metadata, read_file_content, procedure_from_js_file]
     for custom_filter in filters:
         env.filters[custom_filter.__name__] = custom_filter
-
-    template = env.from_string(template_path.read_text())
-    result = template.render(**data)
+    loaded_template = env.get_template(template_path.name)
+    rendered_result = loaded_template.render(**data)
     if output_file_path:
-        output_file_path.write_text(result)
+        output_file_path.write_text(rendered_result)
     else:
-        print(result)
+        print(rendered_result)

--- a/tests/nativeapp/test_commands.py
+++ b/tests/nativeapp/test_commands.py
@@ -1,10 +1,5 @@
-import contextlib
-import os
 import pytest
-from tempfile import NamedTemporaryFile, TemporaryDirectory
-from textwrap import dedent
 from unittest import mock
-from unittest.mock import call
 from subprocess import CalledProcessError
 
 from tests.testing_utils.fixtures import *

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -52,6 +52,7 @@ function foo() {};
 module.exports = foo;
 })()
 return module.exports.apply(this, arguments);
+
 """
     )
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch. [as of Sept 5, 3:17PM EST]
   * [x] I've described my changes in the section below.

### Changes description
The basic template for native apps will have a readme.md.jinja checked in the repository, and at init time, we need to populate the readme with the default value for `application_name`. 
This PR also includes some refactor from a discussion with the snowCLI team in `test_render.py`.
